### PR TITLE
fix calls to flash-script in documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@ The flake has only one single output i.e. ~utils-factory~ which takes the follow
   src # local path with the firmware source (the directory normally inside $QMK_HOME/keyboards/)
 , keyboard-name # name of the keyboard (the name of the directory inside $QMK_HOME/keyboards/)
 , keymap-name # name of the keymap
-, flash-command ? null # needed only for flashing using the "flasher" output
+, flash-script ? null # needed only for flashing using the "flasher" output
 , extra-build-inputs ? [ ] # extra dependencies needed during the build
 , qmk-firmware-source ? qmk-firmware-default-source # the "qmk_firmware" that will be used
 , avr ? true # these may be needed according the target architecture (used in the devShell)

--- a/utils/default.nix
+++ b/utils/default.nix
@@ -47,7 +47,7 @@ let
 
   flasher =
     if builtins.isNull flash-script
-    then builtins.throw "You need to pass a \"flash-command\" to \"utils-factory\""
+    then builtins.throw "You need to pass a \"flash-script\" to \"utils-factory\""
     else
       pkgs.writeShellScriptBin "flasher" ''
         HEX_FILE=${hex}/${keyboard-name}_${keymap-name}.hex


### PR DESCRIPTION
Commit https://github.com/aciceri/qmk-nix-utils/commit/37b8eb29560db16d7a9b449c91775497ab0ef1cf renamed `flash-command` to `flash-script` but it didn't update the references in the documentation.