### PR TITLE
Fix keyboard building

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -20,11 +23,11 @@
         "flake-utils": "flake-utils"
       },
       "locked": {
-        "lastModified": 1639385028,
-        "narHash": "sha256-oqorKz3mwf7UuDJwlbCEYCB2LfcWLL0DkeCWhRIL820=",
+        "lastModified": 1738591040,
+        "narHash": "sha256-4WNeriUToshQ/L5J+dTSWC5OJIwT39SEP7V7oylndi8=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "be1be083af014720c14f3b574f57b6173b4915d0",
+        "rev": "afcb15b845e74ac5e998358709b2b5fe42a948d1",
         "type": "github"
       },
       "original": {
@@ -36,11 +39,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1691279975,
-        "narHash": "sha256-EwPVVuQJGf77NOlX96FE9bpbFGz1wq/M4sqJ6Vk4LyM=",
+        "lastModified": 1752596105,
+        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97bd658852ce0efbdc4d9ca84ad466a4cbfb1cf4",
+        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
         "type": "github"
       },
       "original": {
@@ -54,6 +57,21 @@
       "inputs": {
         "flake-utils-plus": "flake-utils-plus",
         "nixpkgsUnstable": "nixpkgsUnstable"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/utils/default.nix
+++ b/utils/default.nix
@@ -17,20 +17,23 @@ let
   qmk-with-keyboard-src = mkDerivation {
     name = "qmk-with-keyboard-src";
     src = qmk-firmware-source;
+    srcs = firmware-path;
     phases = [ "installPhase" ];
 
     installPhase = let
       target_dir = if type == "keyboard" then
-        "$out/keyboards"
+      "$out/keyboards/${keyboard-name}"
       else if type == "keymap" then
         "$out/keyboards/${keyboard-name}/keymaps"
       else throw "The only values valid for type are 'keyboard' and 'keymap'.";
     in ''
       mkdir "$out"
       cp -r "$src"/* "$out"
+      chmod +w -R $out
+      mkdir -p ${target_dir}
       chmod +w ${target_dir}
-      cp -r ${firmware-path} ${target_dir}/${keymap-name}
-      chmod -w ${target_dir}
+      cp -r ${firmware-path}/* ${target_dir}/
+      chmod -w -R $out
     '';
   };
 

--- a/utils/dev-shell.nix
+++ b/utils/dev-shell.nix
@@ -32,7 +32,7 @@ in
 
 with pkgs;
 let
-  avrlibc = pkgsCross.avr.libcCross;
+  avrlibc = pkgsCross.avr.libc;
 
   avr_incflags = [
     "-isystem ${avrlibc}/avr/include"
@@ -61,7 +61,7 @@ mkShell {
   ]
   ++ lib.optional avr [
     pkgsCross.avr.buildPackages.binutils
-    pkgsCross.avr.buildPackages.gcc8
+    pkgsCross.avr.buildPackages.gcc
     avrlibc
     avrdude
   ]


### PR DESCRIPTION
Currently if you try to build with the keyboard type, the keyboard is incorrectly copied to the wrong location. In addition, when the source for your keyboard (or keymap) is modified, the flake does not pick up on the change when building the source derivation.

This PR fixes both of these issues.