### PR TITLE
feat: Add `*.bin` to the environment variables when flashing

### DIFF
--- a/utils/default.nix
+++ b/utils/default.nix
@@ -57,6 +57,7 @@ let
     else
       pkgs.writeShellScriptBin "flasher" ''
         HEX_FILE=$(find ${hex}/ -type f -name "*.hex" | head -n 1)
+        BIN_FILE=$(find ${hex}/ -type f -name "*.bin" | head -n 1)
         
         ${flash-script}
       '';


### PR DESCRIPTION
Some keyboards need to use the `.bin` instead, so adding it to the potential variables to select from makes sense.